### PR TITLE
pepabo org に移管

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            yano3/nginx-ngx_mruby
-            ghcr.io/yano3/nginx-ngx_mruby
+            ghcr.io/pepabo/nginx-ngx_mruby
           tags: |
             type=ref,event=tag
             type=raw,value=${{ steps.version.outputs.result }}
@@ -44,12 +43,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_ID }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2
@@ -66,10 +59,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-
-      - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_ID }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          repository: yano3/nginx-ngx_mruby

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # nginx with ngx\_mruby module Docker Image
 
-[![Docker Image CI](https://github.com/yano3/docker-nginx-ngx_mruby/actions/workflows/ci.yml/badge.svg)](https://github.com/yano3/docker-nginx-ngx_mruby/actions/workflows/ci.yml)
-[![Docker Pulls](https://img.shields.io/docker/pulls/yano3/nginx-ngx_mruby)](https://hub.docker.com/r/yano3/nginx-ngx_mruby)
+[![Docker Image CI](https://github.com/pepabo/docker-nginx-ngx_mruby/actions/workflows/ci.yml/badge.svg)](https://github.com/pepabo/docker-nginx-ngx_mruby/actions/workflows/ci.yml)
 
 Docker image for nginx with [ngx\_mruby](http://ngx.mruby.org/) dynamic module based on nginx [official image](https://hub.docker.com/_/nginx/).


### PR DESCRIPTION
pepabo/docker-nginx-ngx_mruby に移管し、ghci.io/pepabo/nginx-ngx_mruby として扱えるようにします