### PR TITLE
update ngx_mruby to v2.3.0

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -24,7 +24,9 @@ MRuby::Build.new('host') do |conf|
   conf.gem :github => 'matsumotory/mruby-userdata'
   conf.gem :github => 'matsumotory/mruby-uname'
   conf.gem :github => 'matsumotory/mruby-mutex'
-  conf.gem :github => 'matsumotory/mruby-localmemcache'
+  # FIXME: Can be removed "checksum_hash" upgraded to mruby 3.2
+  # https://github.com/matsumotory/mruby-localmemcache/issues/8
+  conf.gem :github => 'matsumotory/mruby-localmemcache', :checksum_hash => 'ae9e0f0816a7610a1237e86ad18db01d1459498b'
   conf.gem :mgem => 'mruby-secure-random'
 
   # ngx_mruby extended class

--- a/mainline/Dockerfile
+++ b/mainline/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.23.3
 
-ENV NGX_MRUBY_VERSION 2.2.5
+ENV NGX_MRUBY_VERSION 2.3.0
 
 COPY build_config.rb /tmp/
 
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
 
 FROM nginx:1.23.3
 
-ENV NGX_MRUBY_VERSION 2.2.5
+ENV NGX_MRUBY_VERSION 2.3.0
 
 COPY --from=0 /usr/local/src/nginx-$NGINX_VERSION/objs/*.so /etc/nginx/modules/
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.22.1
 
-ENV NGX_MRUBY_VERSION 2.2.5
+ENV NGX_MRUBY_VERSION 2.3.0
 
 COPY build_config.rb /tmp/
 
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
 
 FROM nginx:1.22.1
 
-ENV NGX_MRUBY_VERSION 2.2.5
+ENV NGX_MRUBY_VERSION 2.3.0
 
 COPY --from=0 /usr/local/src/nginx-$NGINX_VERSION/objs/*.so /etc/nginx/modules/
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Update ngx_mruby to [v2.3.0](https://github.com/matsumotory/ngx_mruby/releases/tag/v2.3.0) in stable and mainline nginx image. 