### PR TITLE
Update nginx to v1.24.0

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22.1
+FROM nginx:1.24.0
 
 ENV NGX_MRUBY_VERSION 2.3.0
 
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     --add-dynamic-module=../ngx_mruby/dependence/ngx_devel_kit \
  && make modules
 
-FROM nginx:1.22.1
+FROM nginx:1.24.0
 
 ENV NGX_MRUBY_VERSION 2.3.0
 


### PR DESCRIPTION
https://nginx.org/

<blockquote>

**2023-04-11**

[nginx-1.24.0](https://nginx.org/en/download.html) stable version has been released, incorporating new features and bug fixes from the 1.23.x mainline branch  — including improved handling of multiple header lines with identical names, memory usage optimization in configurations with SSL proxying, better sanity checking of the [listen](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen) directive protocol parameters, [TLSv1.3 protocol](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols) enabled by default, automatic rotation of TLS session tickets encryption keys when using shared memory in the [ssl_session_cache](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache) directive, and more.

</blockquote>